### PR TITLE
feat: add forced deployment rollout to deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,10 @@ jobs:
         echo "🚀 Deploying operator..."
         kubectl apply -f config/manager/manager.yaml
         
+        # Force rollout by restarting the deployment
+        echo "🔄 Forcing deployment rollout..."
+        kubectl rollout restart deployment/pishop-operator -n pishop-operator-system
+        
         # Wait for rollout
         echo "⏳ Waiting for rollout to complete..."
         kubectl rollout status deployment/pishop-operator -n pishop-operator-system --timeout=300s


### PR DESCRIPTION
## Changes

This PR adds a forced deployment rollout step to the GitHub Actions deploy pipeline to ensure the operator deployment is properly updated with new images.

### What's Changed
- Added `kubectl rollout restart` command after applying the deployment manifest
- Forces pod recreation to ensure new image is pulled and used
- Improves deployment reliability by guaranteeing the deployment is restarted

### Why This Change
- Kubernetes deployments don't always restart pods when only the image tag changes
- This ensures the operator always uses the latest deployed image
- Provides more reliable deployments for the PiShop operator

### Testing
- The change has been tested in the existing pipeline structure
- No breaking changes to existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment process to ensure controlled operator restarts with verification of successful rollouts before completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->